### PR TITLE
feat: add pack validation CI workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,18 @@
+name: Validate
+on:
+  push:
+    paths:
+      - "default/**"
+      - "data/**"
+      - "package.json"
+  pull_request:
+    paths:
+      - "default/**"
+      - "data/**"
+      - "package.json"
+
+jobs:
+  validate:
+    uses: JacobPEvans/.github/.github/workflows/_cribl-pack-validate.yml@main
+    with:
+      pack-type: edge

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,11 +5,16 @@ on:
       - "default/**"
       - "data/**"
       - "package.json"
+      - ".github/workflows/validate.yml"
   pull_request:
     paths:
       - "default/**"
       - "data/**"
       - "package.json"
+      - ".github/workflows/validate.yml"
+  workflow_dispatch:
+
+permissions: {}
 
 jobs:
   validate:


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/validate.yml` that calls the shared `_cribl-pack-validate.yml` reusable workflow from `JacobPEvans/.github`
- Configured with `pack-type: edge` for Cribl Edge pack validation
- Triggers on push/PR changes to `default/**`, `data/**`, `package.json`, and `.github/workflows/validate.yml`
- Includes `workflow_dispatch` for manual runs
- Minimal `permissions: {}` block satisfies CodeQL security scanning requirements

## Changes

- New file: `.github/workflows/validate.yml`

## Status

- [x] CodeQL: 0 open alerts
- [x] CI checks: all passing (Analyze + CodeQL)
- [x] Mergeable: CLEAN
- [x] No open review threads

## Test Plan

- [x] CI passes (CodeQL workflow succeeded on PR)
- [ ] Verify `workflow_dispatch` allows manual trigger post-merge
- [ ] Confirm reusable workflow in `JacobPEvans/.github` PR #132 has merged to main before triggering pack validation run

Closes #6
