### PR TITLE
fix(inputs): match .jsonl session files written by gemini CLI 0.43.0+

### DIFF
--- a/default/inputs.yml
+++ b/default/inputs.yml
@@ -8,6 +8,7 @@ inputs:
     interval: 30
     filenames:
       - "*session-*.json"
+      - "*session-*.jsonl"
     filterArchivedFiles: false
     tailOnly: true
     idleTimeout: 300


### PR DESCRIPTION
## Summary

Gemini CLI 0.43.0 changed its session output extension from `.json` to `.jsonl`. The `gemini-cli-sessions` FileMonitor input only matches `*session-*.json`, so new sessions never reach the pipeline.

## Why

Surfaced by an orbstack-kubernetes E2E run today (2026-05-25) — `test_gemini_session_sourcetype` invokes the real `gemini` CLI, polls Splunk for 120s for the sentinel ID, and fails because no event ever arrives. Verified the sentinel landed on disk at:

\`\`\`
~/.gemini/tmp/<workdir>/chats/session-2026-05-25T19-21-5ccf8b76.jsonl
\`\`\`

Counted local session-file extensions: 113 \`.json\` (older) + 1 \`.jsonl\` (the new test run). gemini-cli flipped the extension as of 0.43.0.

## Fix

Add \`*session-*.jsonl\` to the \`filenames\` list. Keep the \`*session-*.json\` entry so older session files on disk still get forwarded.

## Test plan

- [ ] Merge + release
- [ ] Restart \`cribl-edge-standalone-0\` pod in orbstack-kubernetes to pull the new pack version
- [ ] Re-run \`make test-sourcetypes\` in orbstack-kubernetes — \`test_gemini_session_sourcetype\` should pass

Assisted-by: Claude <noreply@anthropic.com>