### PR TITLE
chore(ci): add daily-malicious-code-scan.lock caller [routine:distributor]

### DIFF
--- a/.github/workflows/daily-malicious-code-scan.lock.yml
+++ b/.github/workflows/daily-malicious-code-scan.lock.yml
@@ -1,0 +1,8 @@
+name: daily-malicious-code-scan.lock
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+jobs:
+  run:
+    uses: JacobPEvans/ai-workflows/.github/workflows/daily-malicious-code-scan.lock.yml@facc9a67ffdda22c75f5a94964fc5ab266cf3a60 # v0.16.0


### PR DESCRIPTION
The Distributor propagation PR.

## Workflow

`daily-malicious-code-scan.lock.yml` — thin caller for [JacobPEvans/ai-workflows](https://github.com/JacobPEvans/ai-workflows) reusable workflow, pinned to `facc9a67ffdda22c75f5a94964fc5ab266cf3a60` (`v0.16.0`).

## Why this repo

Repo has `.github/workflows/` directory → core tier.

## Required secrets

None — this workflow uses only public APIs and the runner-injected `GITHUB_TOKEN`.

## Checklist

- [ ] Workflow trigger appropriate for this repo's branch model
- [ ] Required secrets exist in repo settings (if applicable)
- [ ] CI passes on the PR branch before merge

## Provenance

- **Generated by:** [The Distributor](https://claude.ai/code/session_015GGqPiJQ1YnwMk6uBeuix8) — cloud routine, daily at 14:00 UTC
- **Triggered:** Scheduled run on `2026-06-01`
- **Why this PR:** `JacobPEvans-personal/cc-edge-gemini-antigravity-io` matched the `core` tier predicate and is missing `daily-malicious-code-scan.lock.yml` (Phase 4 gap rank #2).
- **State:** `distributor-state` gist — tracks closed-pair memory so previously-rejected combinations are not re-attempted.
- **Label:** `cloud-routine`
