### PR TITLE
chore(ci): extract build-crbl-pack inline run-block to scripts/ [routine:inspector]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,7 @@ jobs:
         env:
           REPO_NAME: ${{ github.event.repository.name }}
           TAG_NAME: ${{ github.event.release.tag_name }}
-        run: |
-          # Versioned filename for archival
-          tar -czf "${REPO_NAME}-${TAG_NAME}.crbl" \
-            data default package.json README.md
-          # Fixed filename for latest-download URLs
-          cp "${REPO_NAME}-${TAG_NAME}.crbl" "${REPO_NAME}.crbl"
+        run: bash scripts/build-crbl-pack.sh
 
       - name: Upload to release
         env:

--- a/scripts/build-crbl-pack.sh
+++ b/scripts/build-crbl-pack.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Versioned filename for archival
+tar -czf "${REPO_NAME}-${TAG_NAME}.crbl" \
+  data default package.json README.md
+# Fixed filename for latest-download URLs
+cp "${REPO_NAME}-${TAG_NAME}.crbl" "${REPO_NAME}.crbl"


### PR DESCRIPTION
The Inspector report.

## Rule

`no-scripts` — inline workflow logic belongs in versioned shell scripts, not run-blocks

## Finding

File: `.github/workflows/release.yml`
Line range: `L1-L38` (Build .crbl pack step, lines 20-28)
Severity: `low` (1 violation: 5 non-blank lines in run-block; no open PR blocking this file)

Violation: The `Build .crbl pack` step contained a 5-line inline run-block — above the 4-non-blank-line threshold for the no-scripts rule — with real build logic (tar + cp).

## Action

Extracted the inline run-block to `scripts/build-crbl-pack.sh` and replaced the step's `run:` with `run: bash scripts/build-crbl-pack.sh`. No semantic change. YAML parse passed; re-scan returns zero violations.

Note: the same pattern exists in `cc-edge-copilot-otel` and `cc-stream-github-copilot-rest-io` — future runs will follow up on those.

---

## Provenance

- **Generated by:** [The Inspector](https://github.com/JacobPEvans-personal/.github/blob/main/routines/inspector.prompt.md) — cloud routine, daily at 06:00 UTC.
- **Triggered:** Today's rotation landed on rule `no-scripts` (day-of-epoch mod 3 = 2).
- **Why this PR/issue:** `cc-edge-gemini-antigravity-io` had the largest unblocked extractable run-block in the no-scripts scan (5 non-blank lines; secrets-sync/screenpipe-mirror/JacobPEvans all blocked by existing open PRs).
- **State:** `inspector-state` gist — tracks per-`(repo, rule)` cooldowns and content-hash caches.
- **Label:** `cloud-routine`