### PR TITLE
docs(cc-edge-gemini-antigravity-io): add Quick Start section [routine:archivist]

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ and forwards it to a Cribl Stream worker group for indexing, analysis, and searc
 3. **Annotations** — `~/.gemini/antigravity/annotations/*.pbtxt` — Annotation protobuf text metadata
 4. **Code tracker** — `~/.gemini/antigravity/code_tracker/**/*` — Code tracking snapshots and file state across active and historical sessions
 
+## Quick Start
+
+1. **Install the pack** into Cribl Edge via the pack registry or by uploading the `.crbl` zip file.
+2. **Set `GEMINI_HOME`** and configure Gemini CLI telemetry (run once on the Edge host):
+   ```bash
+   export GEMINI_HOME=/Users/<your-username>
+   export GEMINI_TELEMETRY_ENABLED=true
+   export GEMINI_TELEMETRY_OTLP_ENDPOINT=http://localhost:4321
+   ```
+3. **Restart Cribl Edge** so it picks up the environment variable.
+4. **Grant read permissions** if Cribl Edge runs as a different user than the one that owns the Gemini/Antigravity files — see the [Setup](#setup) section for the `chmod +a` commands.
+
+For co-deployment with other AI observability packs on the same Edge node, override the OTLP port to **`4321`** to avoid conflicts — see [Setup → Port Allocation](#setup).
+
 ## Architecture
 
 ```text


### PR DESCRIPTION
The Archivist README quality fix.

## Gap

Check 3 failed: `missing_quickstart`. The README has a comprehensive `## Setup` section at line 182 but no recognized quickstart heading (`## Quick Start`, `## Install`, `## Installation`, `## Getting Started`, or `## Setup`) within the first 80 lines. The README quality scorer measures six items from <https://www.makeareadme.com/> and <https://github.com/matiassingers/awesome-readme>.

## Proposed fix

Added a `## Quick Start` section after the Overview (now at line 29), condensing the essential steps — pack installation, `GEMINI_HOME` export with `GEMINI_TELEMETRY_*` variables, and Cribl Edge restart — with a three-line code block. The full `## Setup` section (port allocation, filesystem permissions) is unchanged.

## Other checks

| # | Check | Status |
| --- | --- | --- |
| 1 | Exists | ✓ |
| 2 | Purpose paragraph | ✓ |
| 3 | Quickstart | ✗ → ✓ (fixed) |
| 4 | Usage/examples (Quickstart code block) | ✓ |
| 5 | License | ✓ |
| 6 | Length (non-blank lines 30–400) | ✓ |

---

## Provenance

- **Generated by:** [The Archivist](https://github.com/JacobPEvans-personal/.github) — cloud routine, daily at 09:00 UTC, task `readme-quality`.
- **Triggered:** Daily rotation landed on `readme-quality` (day-of-epoch-seconds mod 2 = 0, 2026-06-18).
- **Why this PR:** `JacobPEvans-personal/cc-edge-gemini-antigravity-io` scored 4/6 (gap: `missing_quickstart`); score-0 repos blocked by open issues; score-2 repo (`int_ai-assistant-contexts`) blocked by open archivist PR; `GoatSearchTest` prior archivist PR closed without merge; this repo is next most-recently-pushed eligible at 4/6 (pushed 2026-06-17).
- **State:** `archivist-state` gist — 14-day cooldown per `(repo, task)`; routine-pr-budget gist missing (fail-open).
- **Label:** `cloud-routine`
